### PR TITLE
Update plugin to IntelliJ 2019.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.jetbrains.intellij' version '0.4.7'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.21'
+    id 'org.jetbrains.intellij' version '0.4.10'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
 }
 
 group 'world.gregs.intellij.plugins'
@@ -28,7 +28,8 @@ processResources {
 }
 
 intellij {
-    version '2019.1'
+    version '2019.2'
+    plugins 'java'
 }
 patchPluginXml {
     changeNotes """
@@ -41,5 +42,7 @@ patchPluginXml {
         Added fix tests<br>
         <br>
         Updated to support 2019.1
+        <br>
+        Updated to support 2019.2
       """
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -7,12 +7,8 @@
     A few intellij plugins to assist refactoring obfuscated code<br>
     ]]></description>
 
-    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
-         on how to target different products -->
-    <!-- uncomment to enable plugin in all products
-    <depends>com.intellij.modules.lang</depends>
-    -->
-    <idea-version since-build="162" until-build="191.*"/>
+    <depends>com.intellij.modules.java</depends>
+    <idea-version since-build="162" until-build="192.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <localInspection groupPath="Java" language="JAVA" shortName="PointlessBitwiseComparator" bundle="world.gregs.intellij.plugins.DeobfuscateToolBundle"


### PR DESCRIPTION
This is required due to changes described in https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/.